### PR TITLE
Added new setting for implicitly_wait

### DIFF
--- a/django_selenium/settings.py
+++ b/django_selenium/settings.py
@@ -5,10 +5,12 @@ SELENIUM_TEST_RUNNER = getattr(settings, 'SELENIUM_TEST_RUNNER',
                              'django_selenium.selenium_runner.SeleniumTestRunner')
 
 SELENIUM_TIMEOUT = getattr(settings, 'SELENIUM_TIMEOUT', 120)
+SELENIUM_IMPLICITLY_TIMEOUT = getattr(settings, 'SELENIUM_IMPLICITLY_TIMEOUT', 1)
 
 #------------------ LOCAL ----------------------------------
 SELENIUM_TESTSERVER_HOST = getattr(settings, 'SELENIUM_TESTSERVER_HOST', 'localhost')
 SELENIUM_TESTSERVER_PORT = getattr(settings, 'SELENIUM_TESTSERVER_PORT', 8011)
+
 SELENIUM_HOST = getattr(settings, 'SELENIUM_HOST', None)
 SELENIUM_PORT = getattr(settings, 'SELENIUM_PORT', 4444)
 

--- a/django_selenium/testcases.py
+++ b/django_selenium/testcases.py
@@ -125,13 +125,14 @@ class MyDriver(object):
         elem.clear()
         elem.send_keys(text)
 
+
 class SeleniumTestCase(TransactionTestCase):
 
     def __getattribute__(self, name):
         try:
             attr = object.__getattribute__(self, name)
         except AttributeError:
-            attr = object.__getattribute__(self,'driver').__getattribute__(name)
+            attr = object.__getattribute__(self, 'driver').__getattribute__(name)
         return attr
 
     def _fixture_setup(self):
@@ -146,8 +147,7 @@ class SeleniumTestCase(TransactionTestCase):
         import socket
         socket.setdefaulttimeout(settings.SELENIUM_TIMEOUT)
         self.driver = MyDriver()
-        self.driver.implicitly_wait(settings.SELENIUM_TIMEOUT)
+        self.driver.implicitly_wait(settings.SELENIUM_IMPLICITLY_TIMEOUT)
 
     def tearDown(self):
         self.driver.quit()
-


### PR DESCRIPTION
Я буду писать по-русски, думаю должно быть понятно :)

Для установки этого ожидания нужна отдельная настройка, иначе она берется равной 120. И получается что все функции для нахождения нод, которые должны выдавать ексепшин если такой ноды нет будут ждать 120 сукунд прежде чем его зарейзить.
Речь идет например о таких функциях: is_element_present, find_element, find_elements - если ничего не найдено будет ждать на величину SELENIUM_TIMEOUT

Внешне это выглядит совсем странно - у меня должен вылететь ексепшин, а вместо этого процесс тестирования замирает аж на 120 секунд. Я вначале просто думал, что мои тесты виснут - случано один раз оставил тесты и пошел курить, благодаря чему и обнаружил, это поведение.

Короче я просто разделил настройки для setdefaulttimeout и implicitly_wait
