### PR TITLE
Allow any button that submits, not just <input>

### DIFF
--- a/django_selenium/testcases.py
+++ b/django_selenium/testcases.py
@@ -92,7 +92,7 @@ class MyDriver(object):
         self.open_url(reverse('login'))
         self.type_in("#id_username", username)
         self.type_in("#id_password", password)
-        self.click("#login-form input[type='submit']")
+        self.click("#login-form [type='submit']")
 
     def update_text(self):
         """


### PR DESCRIPTION
I have a custom login form that is styled with `<button type="submit">` and it would be nice if I could use that without creating my own copy of `authorize`.
