### PR TITLE
Tests dropped due to deadlock

### DIFF
--- a/django_selenium/selenium_runner.py
+++ b/django_selenium/selenium_runner.py
@@ -8,7 +8,7 @@ import unittest
 from django_selenium import settings
 from django.test.simple import reorder_suite
 from django.test.testcases import TestCase
-from django_selenium.selenium_server import start_test_server
+from django_selenium.selenium_server import get_test_server
 
 try:
     from django.test.simple import DjangoTestSuiteRunner
@@ -97,7 +97,7 @@ class SeleniumTestRunner(DjangoTestSuiteRunner):
             # Set display variable
             os.environ['DISPLAY'] = settings.SELENIUM_DISPLAY
             # Start test server
-            self.test_server = start_test_server(address=settings.SELENIUM_TESTSERVER_HOST, port=settings.SELENIUM_TESTSERVER_PORT)
+            self.test_server = get_test_server()
             if self._is_start_selenium_server():
                 # Start selenium server
                 self.selenium_server = subprocess.Popen(('java -jar %s' % settings.SELENIUM_PATH).split())

--- a/django_selenium/settings.py
+++ b/django_selenium/settings.py
@@ -6,6 +6,8 @@ SELENIUM_TEST_RUNNER = getattr(settings, 'SELENIUM_TEST_RUNNER',
 
 SELENIUM_TIMEOUT = getattr(settings, 'SELENIUM_TIMEOUT', 120)
 SELENIUM_DRIVER_TIMEOUT = getattr(settings, 'SELENIUM_DRIVER_TIMEOUT', 10)
+# Specify max waiting time for server to finish processing request and deactivates
+SELENIUM_TEST_SERVER_TIMEOUT = getattr(settings, 'SELENIUM_TEST_SERVER_TIMEOUT', 300)
 
 #------------------ LOCAL ----------------------------------
 SELENIUM_TESTSERVER_HOST = getattr(settings, 'SELENIUM_TESTSERVER_HOST', 'localhost')

--- a/django_selenium/testcases.py
+++ b/django_selenium/testcases.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
 from django.utils.html import strip_tags
 
-from django_selenium import settings
+from django_selenium import settings, selenium_server
 
 
 def wait(func):
@@ -204,12 +204,15 @@ class SeleniumTestCase(TransactionTestCase):
         return attr
 
     def _fixture_setup(self):
+        test_server = selenium_server.get_test_server()
+        test_server.deactivate()
         transaction.commit_unless_managed()
         transaction.enter_transaction_management()
         transaction.managed(True)
         super(SeleniumTestCase, self)._fixture_setup()
         transaction.commit()
         transaction.leave_transaction_management()
+        test_server.activate()
 
     def setUp(self):
         import socket


### PR DESCRIPTION
Sometimes occur situation when request handling takes too long and test execution stopped, while request keep hangling. Then fixture for new test starts loading and try to flash Database table and if request handler work with same table at this monet this may cause deadlock. Solution: stop handling request while loading fixtures.
