### PR TITLE
Erased the comma

### DIFF
--- a/django_selenium/selenium_server.py
+++ b/django_selenium/selenium_server.py
@@ -58,7 +58,7 @@ class TestServerThread(threading.Thread):
             httpd = StoppableWSGIServer(server_address, basehttp.WSGIRequestHandler)
             httpd.set_app(test_app)
             self._start_event.set()
-        except wsgi_exec_error, e:
+        except wsgi_exec_error e:
             self.error = e
             self._start_event.set()
             return


### PR DESCRIPTION
When trying to install I ran into "SyntaxError" - that comma should not be there

Error appeared only when trying to install with pip -- it didn't appear when I manually downloaded and installed it
