### PR TITLE
Allow custom selenium webdriver options via SELENIUM_DRIVER_OPTS

### DIFF
--- a/django_selenium/testcases.py
+++ b/django_selenium/testcases.py
@@ -58,15 +58,16 @@ class MyDriver(object):
     def __init__(self):
         driver = getattr(webdriver, settings.SELENIUM_DRIVER, None)
         assert driver, "settings.SELENIUM_DRIVER contains non-existing driver"
+        driver_opts = getattr(settings, "SELENIUM_DRIVER_OPTS", dict())
         if driver is webdriver.Remote:
             if isinstance(settings.SELENIUM_CAPABILITY, dict):
                 capability = settings.SELENIUM_CAPABILITY
             else:
                 capability = getattr(webdriver.DesiredCapabilities, settings.SELENIUM_CAPABILITY, None)
                 assert capability, 'settings.SELENIUM_CAPABILITY contains non-existing capability'
-            self.driver = driver('http://%s:%d/wd/hub' % (settings.SELENIUM_HOST, settings.SELENIUM_PORT), capability)
+            self.driver = driver('http://%s:%d/wd/hub' % (settings.SELENIUM_HOST, settings.SELENIUM_PORT), capability, **driver_opts)
         else:
-            self.driver = driver()
+            self.driver = driver(**driver_opts)
         self.live_server_url = 'http://%s:%s' % (settings.SELENIUM_TESTSERVER_HOST , str(settings.SELENIUM_TESTSERVER_PORT))
         self.text = ''
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,12 @@ So, if you plan to use **selenium locally**, then you should define the followin
 
 - Set ``SELENIUM_DRIVER`` for corresponding browser driver in selenium.
 
+- Optionally, set ``SELENIUM_DRIVER_OPTS`` as a dictionary with options to be passed to the selenium
+  webdriver. This option can be used for instance to pass a custom firefox profile path to be used,
+  or a custom path for ``chromedriver``. See the `Selenium webdriver's drivers`_ page for more information.
+
+.. _`Selenium webdriver's drivers`: http://docs.seleniumhq.org/docs/03_webdriver.jsp#selenium-webdriver-s-drivers
+
 
 Remote
 ------


### PR DESCRIPTION
Please consider merging the following patch to django-selenium.
It addresses in a general way issue #16, offering the possibility of passing
custom arguments to the selenium webdriver.

It can be used to pass custom paths for firefox, chromedriver, etc and also
to pass custom options for each webdriver, such as a custom firefox profile.

I have added the respective documentation, to make adoption of the patch
as easy as possible.

Any comments will be very much appreciated. Thank you for your time.
